### PR TITLE
Add Gem release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Publish Gem
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Release Gem
+        uses: cadwallion/publish-rubygems-action@b8b21c36ec884b3ad47707724b30e54330bca267
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: bundle exec rake release


### PR DESCRIPTION
The action that we're using is pinned to a specific SHA to keep our RubyGems secret safe. I have audited the action at this commit SHA