### PR TITLE
Add basic config for Go code snippets to the renderer

### DIFF
--- a/config/code_languages.yml
+++ b/config/code_languages.yml
@@ -109,6 +109,15 @@ languages:
     icon: ios
     dependencies: []
 
+  go:
+    weight: 12 
+    label: Go
+    lexer: go
+    icon: curl
+    dependencies:
+      - 'vonage/vonage-go-sdk'
+    run_command: 'go run {filename}'
+ 
 platforms:
   ios:
     languages:

--- a/lib/nexmo_markdown_renderer.rb
+++ b/lib/nexmo_markdown_renderer.rb
@@ -24,6 +24,7 @@ require_relative 'nexmo_markdown_renderer/services/code_snippet_renderer/php'
 require_relative 'nexmo_markdown_renderer/services/code_snippet_renderer/python'
 require_relative 'nexmo_markdown_renderer/services/code_snippet_renderer/ruby'
 require_relative 'nexmo_markdown_renderer/services/code_snippet_renderer/swift'
+require_relative 'nexmo_markdown_renderer/services/code_snippet_renderer/go'
 
 require_relative 'nexmo_markdown_renderer/services/doc_finder'
 require_relative 'nexmo_markdown_renderer/services/doc_finder/doc'

--- a/lib/nexmo_markdown_renderer/filters/code_snippet/renderable.rb
+++ b/lib/nexmo_markdown_renderer/filters/code_snippet/renderable.rb
@@ -43,6 +43,8 @@ module Nexmo
               Nexmo::Markdown::CodeSnippetRenderer::ObjectiveC
             when 'swift'
               Nexmo::Markdown::CodeSnippetRenderer::Swift
+            when 'go'
+              Nexmo::Markdown::CodeSnippetRenderer::Go
             else
               raise "Unknown language: #{normalized_language}"
             end

--- a/lib/nexmo_markdown_renderer/services/code_snippet_renderer/go.rb
+++ b/lib/nexmo_markdown_renderer/services/code_snippet_renderer/go.rb
@@ -1,0 +1,23 @@
+module Nexmo
+  module Markdown
+    module CodeSnippetRenderer
+      class Go < Base
+        def self.dependencies(deps, _version)
+          { 'code' => "go get #{deps.join(' ')}" }
+        end
+    
+        def self.run_command(command, _filename, _file_path)
+          ::I18n.t('services.code_snippet_renderer.run_command', command: command)
+        end
+    
+        def self.create_instructions(filename)
+          ::I18n.t('services.code_snippet_renderer.create_instructions', filename: filename)
+        end
+    
+        def self.add_instructions(_filename)
+          ::I18n.t('services.code_snippet_renderer.add_instructions_to_code')
+        end
+      end
+    end    
+  end
+end


### PR DESCRIPTION
We're going to add code snippets in Go to the developer portal, so the renderer needs to know how to add them. I'm confused about a few things:
 - where does the icon go?
 - do I need to make the same changes in `config/code_languages.yaml` in station and nexmo-developer repos as well? This file appears in all three places
 - what's a good way to test this locally? I made these changes basically hacking around inside a docker setup of ADP but it's not watertight!