### PR TITLE
Fix string interpolation error

### DIFF
--- a/lib/nexmo_markdown_renderer/filters/markdown_filter.rb
+++ b/lib/nexmo_markdown_renderer/filters/markdown_filter.rb
@@ -64,7 +64,7 @@ module Nexmo
           '<img src="'\
           "#{link}"\
           '" alt="'\
-          "#{alt_text}"\
+          "#{_alt_text}"\
           '">' \
         '</figure>'
       end

--- a/lib/nexmo_markdown_renderer/filters/markdown_filter.rb
+++ b/lib/nexmo_markdown_renderer/filters/markdown_filter.rb
@@ -63,7 +63,9 @@ module Nexmo
         '<figure>' \
           '<img src="'\
           "#{link}"\
-          '" alt="#{alt_text}">' \
+          '" alt="'\
+          "#{alt_text}"\
+          '">' \
         '</figure>'
       end
 

--- a/spec/filters/markdown_filter_spec.rb
+++ b/spec/filters/markdown_filter_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Nexmo::Markdown::MarkdownFilter do
+  describe '#call' do
+    subject { described_class.call(input) }
+
+    context 'converting images' do
+      let(:input) do
+        "![Markdown Image Alt Text](/images/example.png 'Markdown Image Title')"
+      end
+
+      it 'converts markdown images into image tags' do
+        expect(subject).to eq('<p><figure><img src="/images/example.png" alt="Markdown Image Alt Text"></figure></p>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was an error with the string interpolation, which resulted in the string `"#{alt_text}"` being rendered rather than the value of the `_alt_text` variable.

Closes #30 