### PR TITLE
Add SnippetVariables markdown filter

### DIFF
--- a/lib/nexmo_markdown_renderer/filters/snippet_variables_filter.rb
+++ b/lib/nexmo_markdown_renderer/filters/snippet_variables_filter.rb
@@ -1,0 +1,33 @@
+module Nexmo
+  module Markdown
+    class SnippetVariablesFilter < Banzai::Filter
+      def call(input)
+        input.gsub(/```snippet_variables(.+?)```/m) do |_s|
+          config = YAML.safe_load(Regexp.last_match(1))
+
+          raise 'No variables provided' unless config
+          raise 'Must provide a list' unless config.is_a?(Array)
+
+          output = <<~HEREDOC
+            Key | Description
+            -- | --
+          HEREDOC
+          config.each do |key|
+            details = variables[key]
+            raise "#{key} is not a valid snippet variable" unless details
+
+            output += <<~HEREDOC
+              `#{key}` | #{details['description']}
+            HEREDOC
+          end
+
+          output
+        end
+      end
+
+      def variables
+        @variables ||= YAML.safe_load(File.read("#{Nexmo::Markdown::Config.docs_base_path}/config/code_snippet_variables.yml"))
+      end
+    end
+  end
+end

--- a/lib/nexmo_markdown_renderer/filters/snippet_variables_filter.rb
+++ b/lib/nexmo_markdown_renderer/filters/snippet_variables_filter.rb
@@ -6,7 +6,7 @@ module Nexmo
           config = YAML.safe_load(Regexp.last_match(1))
 
           raise 'No variables provided' unless config
-          raise 'Must provide a list' unless config.is_a?(Array)
+          raise 'Must provide an array' unless config.is_a?(Array)
 
           output = <<~HEREDOC
             Key | Description

--- a/lib/nexmo_markdown_renderer/filters/snippet_variables_filter.rb
+++ b/lib/nexmo_markdown_renderer/filters/snippet_variables_filter.rb
@@ -15,6 +15,7 @@ module Nexmo
           config.each do |key|
             details = variables[key]
             raise "#{key} is not a valid snippet variable" unless details
+            raise "#{key} does not have a description" unless details['description']
 
             output += <<~HEREDOC
               `#{key}` | #{details['description']}

--- a/lib/nexmo_markdown_renderer/markdown_renderer.rb
+++ b/lib/nexmo_markdown_renderer/markdown_renderer.rb
@@ -29,6 +29,7 @@ module Nexmo
           ConceptListFilter.new(options),
           LanguageFilter,
           ColumnsFilter,
+          SnippetVariablesFilter,
           MarkdownFilter.new(options),
 
           # As HTML

--- a/spec/filters/snippet_variables_filter_spec.rb
+++ b/spec/filters/snippet_variables_filter_spec.rb
@@ -63,4 +63,17 @@ RSpec.describe Nexmo::Markdown::SnippetVariablesFilter do
       described_class.new.call(input)
     end.to raise_error('INVALID_NAME is not a valid snippet variable')
   end
+
+  it 'throws when a variable does not have a description' do
+    input = <<~HEREDOC
+      ```snippet_variables
+      - NO_DESCRIPTION
+      ```
+    HEREDOC
+
+    expect do
+      described_class.new.call(input)
+    end.to raise_error('NO_DESCRIPTION does not have a description')
+  end
+
 end

--- a/spec/filters/snippet_variables_filter_spec.rb
+++ b/spec/filters/snippet_variables_filter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Nexmo::Markdown::SnippetVariablesFilter do
 
     expect do
       described_class.new.call(input)
-    end.to raise_error('Must provide a list')
+    end.to raise_error('Must provide an array')
   end
 
   it 'throws when a variable cannot be found' do

--- a/spec/filters/snippet_variables_filter_spec.rb
+++ b/spec/filters/snippet_variables_filter_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe Nexmo::Markdown::SnippetVariablesFilter do
+  it 'returns whitespace with whitespace input' do
+    expect(described_class.call('')).to eql('')
+  end
+
+  it 'returns unaltered non-matching input' do
+    input = 'some text'
+    expect(described_class.call(input)).to eql(input)
+  end
+
+  it 'outputs multiple lines' do
+    input = <<~HEREDOC
+      ```snippet_variables
+      - NEXMO_API_KEY
+      - TO_NUMBER
+      ```
+    HEREDOC
+
+    expected_output = <<~HEREDOC
+      Key | Description
+      -- | --
+      `NEXMO_API_KEY` | You can find this in your account overview
+      `TO_NUMBER` | The number you are sending the SMS to in E.164 format. For example `447700900000`.
+
+    HEREDOC
+
+    expect(described_class.call(input)).to eq(expected_output)
+  end
+
+  it 'throws with an empty list' do
+    input = <<~HEREDOC
+      ```snippet_variables
+      ```
+    HEREDOC
+
+    expect do
+      described_class.new.call(input)
+    end.to raise_error('No variables provided')
+  end
+
+  it 'throws with the wrong data type' do
+    input = <<~HEREDOC
+      ```snippet_variables
+      Not a list
+      ```
+    HEREDOC
+
+    expect do
+      described_class.new.call(input)
+    end.to raise_error('Must provide a list')
+  end
+
+  it 'throws when a variable cannot be found' do
+    input = <<~HEREDOC
+      ```snippet_variables
+      - INVALID_NAME
+      ```
+    HEREDOC
+
+    expect do
+      described_class.new.call(input)
+    end.to raise_error('INVALID_NAME is not a valid snippet variable')
+  end
+end

--- a/spec/fixtures/config/code_snippet_variables.yml
+++ b/spec/fixtures/config/code_snippet_variables.yml
@@ -1,0 +1,6 @@
+NEXMO_API_KEY:
+  description: You can find this in your account overview
+NEXMO_API_SECRET:
+  description: You can find this in your account overview
+TO_NUMBER:
+  description: The number you are sending the SMS to in E.164 format. For example `447700900000`.

--- a/spec/fixtures/config/code_snippet_variables.yml
+++ b/spec/fixtures/config/code_snippet_variables.yml
@@ -4,3 +4,5 @@ NEXMO_API_SECRET:
   description: You can find this in your account overview
 TO_NUMBER:
   description: The number you are sending the SMS to in E.164 format. For example `447700900000`.
+NO_DESCRIPTION:
+  desc: This is invalid


### PR DESCRIPTION
This filter allows us to replace the hardcoded list of variables with a consolidated list of variable names and descriptions.

This is useful to:

* Add consistency to variable names when we want to provide customised code snippets
* Allows of translation of the variable descriptions in a single place if we choose to translate code snippet pages