### PR TITLE
Define attributes on class not singleton

### DIFF
--- a/lib/nexmo_markdown_renderer/services/doc_finder.rb
+++ b/lib/nexmo_markdown_renderer/services/doc_finder.rb
@@ -6,8 +6,8 @@ module Nexmo
       EXCLUSIONS = ['.', '..', ::I18n.default_locale.to_s].freeze
 
       class << self
-        mattr_accessor :paths
-        mattr_accessor :dictionary
+        attr_accessor :paths
+        attr_accessor :dictionary
       end
 
       # rubocop:disable Metrics/ParameterLists


### PR DESCRIPTION
As part of the [Rails 6.1 upgrade](https://github.com/Nexmo/station/pull/571) on Station, a `TypeError` was identified in the markdown renderer where module attributes were being defined on the singleton, not on the class. This is now a blocking error in Rails initialization, where previously it was a Ruby language level warning. You can see it's implementation into Rails [here](https://github.com/rails/rails/pull/38144).

The relevant part of the trace of the error is as follows:

```
▶ bundle exec rails assets:precompile --trace
rails aborted!
TypeError: module attributes should be defined directly on class, not singleton
/Users/bgreenberg2/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/module/attribute_accessors.rb:52:in `mattr_reader'
/Users/bgreenberg2/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-6.1.0/lib/active_support/core_ext/module/attribute_accessors.rb:202:in `mattr_accessor'
/Users/bgreenberg2/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/nexmo_markdown_renderer-0.7.3/lib/nexmo_markdown_renderer/services/doc_finder.rb:9:in `singleton class'
/Users/bgreenberg2/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/nexmo_markdown_renderer-0.7.3/lib/nexmo_markdown_renderer/services/doc_finder.rb:8:in `<class:DocFinder>'
/Users/bgreenberg2/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/nexmo_markdown_renderer-0.7.3/lib/nexmo_markdown_renderer/services/doc_finder.rb:3:in `<module:Markdown>'
/Users/bgreenberg2/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/nexmo_markdown_renderer-0.7.3/lib/nexmo_markdown_renderer/services/doc_finder.rb:2:in `<module:Nexmo>'
/Users/bgreenberg2/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/nexmo_markdown_renderer-0.7.3/lib/nexmo_markdown_renderer/services/doc_finder.rb:1:in `<main>'
```