### PR TITLE
Add post-processing for single quotes in curl snippets

### DIFF
--- a/lib/nexmo_markdown_renderer/filters/code_snippet/initialize_dependencies.rb
+++ b/lib/nexmo_markdown_renderer/filters/code_snippet/initialize_dependencies.rb
@@ -19,7 +19,8 @@ module Nexmo
             @highlighted_client_source ||= ::Nexmo::Markdown::Utils.generate_code_block(
               language,
               @config,
-              unindent
+              unindent,
+              renderer
             )
           end
 

--- a/lib/nexmo_markdown_renderer/filters/code_snippet/instructions.rb
+++ b/lib/nexmo_markdown_renderer/filters/code_snippet/instructions.rb
@@ -27,7 +27,8 @@ module Nexmo
             @highlighted_code_source ||= ::Nexmo::Markdown::Utils.generate_code_block(
               language,
               @config['code'],
-              unindent
+              unindent,
+              renderer
             )
           end
 

--- a/lib/nexmo_markdown_renderer/filters/utils.rb
+++ b/lib/nexmo_markdown_renderer/filters/utils.rb
@@ -26,7 +26,7 @@ module Nexmo
         start_section + file_section + line_section
       end
 
-      def self.generate_code_block(language, input, unindent)
+      def self.generate_code_block(language, input, unindent, renderer)
         return '' unless input
         filename = "#{Nexmo::Markdown::Config.docs_base_path}/#{input['source']}"
         raise "CodeSnippetFilter - Could not load #{filename} for language #{language}" unless File.exist?(filename)
@@ -42,6 +42,9 @@ module Nexmo
 
         code = code.lines[from_line..to_line].join
         code.unindent! if unindent
+
+        code = renderer.post_process(code) if renderer.respond_to?(:post_process)
+
         formatter = Rouge::Formatters::HTML.new
         formatter.format(lexer.lex(code))
       end

--- a/lib/nexmo_markdown_renderer/services/code_snippet_renderer/curl.rb
+++ b/lib/nexmo_markdown_renderer/services/code_snippet_renderer/curl.rb
@@ -22,6 +22,14 @@ module Nexmo
         def self.add_instructions(filename)
           ::I18n.t('services.code_snippet_renderer.add_instructions_to_file', file: filename)
         end
+
+        def self.post_process(code)
+          self.strip_single_quotes(code)
+        end
+
+        def self.strip_single_quotes(code)
+          code.gsub(/"'(\$\w+)'"/, '"\1"')
+        end
       end
     end
     

--- a/spec/services/code_snippet_renderer/curl_spec.rb
+++ b/spec/services/code_snippet_renderer/curl_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Nexmo::Markdown::CodeSnippetRenderer::Curl do
+  it 'ignores snippets that do not have single quotes' do
+    input = <<~HEREDOC.strip
+curl -X "POST" "https://rest.nexmo.com/sms/json" \
+  -d "from=$VONAGE_BRAND_NAME" \
+  -d "text=A text message sent using the Vonage SMS API" \
+  -d "to=$TO_NUMBER" \
+  -d "api_key=$VONAGE_API_KEY" \
+  -d "api_secret=$VONAGE_API_SECRET"
+    HEREDOC
+    expect(described_class.post_process(input)).to eq(input)
+  end
+
+  it 'removes single quotes around a variable' do
+    input = <<~HEREDOC.strip
+curl -X POST https://api.nexmo.com/v1/calls\
+  -H "Authorization: Bearer "$JWT\
+  -H "Content-Type: application/json"\
+  -d '{"to":[{"type": "phone","number": "'$TO_NUMBER'"}],
+      "from": {"type": "phone","number": "'$VONAGE_NUMBER'"},
+      "ncco": [
+        {
+          "action": "talk",
+          "text": "This is a text to speech call from Vonage"
+        }
+      ]}'
+    HEREDOC
+
+    expected = <<~HEREDOC.strip
+curl -X POST https://api.nexmo.com/v1/calls\
+  -H "Authorization: Bearer "$JWT\
+  -H "Content-Type: application/json"\
+  -d '{"to":[{"type": "phone","number": "$TO_NUMBER"}],
+      "from": {"type": "phone","number": "$VONAGE_NUMBER"},
+      "ncco": [
+        {
+          "action": "talk",
+          "text": "This is a text to speech call from Vonage"
+        }
+      ]}'
+    HEREDOC
+    expect(described_class.post_process(input)).to eq(expected)
+  end
+end


### PR DESCRIPTION
The single quotes in code snippets are required when executing curl snippets directly but confuse things for display on the docs. This PR adds a post-processing step to remove them when displaying snippets on the docs